### PR TITLE
Update Interp_model2SWOT.py

### DIFF
--- a/Interp_model2SWOT.py
+++ b/Interp_model2SWOT.py
@@ -6,7 +6,7 @@ import pyinterp
 import os
 from scipy import interpolate
 from inpoly.inpoly2 import inpoly2
-import matplotlib.pyplot as plt
+
 
 
 def read_netcdf_files(file1, file2, file3):
@@ -89,32 +89,7 @@ def select_area(lat, lon, var, latitude_array, longitude_array):
         Y.isel(num_pixels=0).values[::-1]+k1
     ])
     
-    # Optional: original swath edge (for plotting only)
     
-    xx1 = np.concatenate([
-        X.isel(num_lines=0).values,
-        X.isel(num_pixels=-1).values,
-        X.isel(num_lines=-1).values[::-1],
-        X.isel(num_pixels=0).values[::-1]
-    ])
-
-    yy1 = np.concatenate([
-        Y.isel(num_lines=0).values,
-        Y.isel(num_pixels=-1).values,
-        Y.isel(num_lines=-1).values[::-1],
-        Y.isel(num_pixels=0).values[::-1]
-    ])
-    
-    # Visualization (optional)
-    plt.figure(figsize=(6, 6))
-    plt.plot(xx, yy, label="Polygon with margin")
-    plt.plot(xx1, yy1, label="Swath edge", linestyle='--')
-    plt.legend()
-    plt.title("Selected Area")
-    plt.xlabel("Longitude")
-    plt.ylabel("Latitude")
-    plt.grid(True)
-    plt.tight_layout()
     
     
     polygon = np.column_stack((xx, yy))  


### PR DESCRIPTION
In this updated code:

1) I modified the read_netcdf_files function to support reading both Zarr and NetCDF files.

2) I introduced a new function called select_area, which limits the data to a region surrounding the interpolation grid. This helps prevent memory issues during interpolation.

3) The select_area function is now called within the open_model_data function to focus on the target region. Consequently, the grid coordinates (latitude_array, longitude_array) have been added as arguments to open_model_data.

4) I added a new argument, cross_dist, to the interp_satellite function. This variable, available in the SWOT files, is used to filter out data in regions where SWOT has no valid observations (such as inter-swath and peripheral areas).