### PR TITLE
Suggested refactoring - type hinting, logging, & CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,61 +2,85 @@
 
 ## 📄 Description:
 
-model2SWOT is an approach designed to interpolate model SSH (Sea Surface Height) data onto the SWOT (Surface Water and Ocean Topography) grid. Given a single daily model data, the script interpolates the SSH data onto a given SWOT swath.
+model2SWOT is an approach designed to interpolate model Sea Surface Height (SSH) data onto Surface Water and Ocean Topography (SWOT) grids. Given a single daily model data, the script interpolates the SSH data onto a given SWOT swath.
 
-### Main Requered Inputs:
+### Required Inputs:
 
-- model files containing SSH data.
-- Model mask containing the longitude and latitude coordinates.
-- SWOT data file containing the target longitude/latitude grid. It is recommended to use the "Expert" version of these files.
+- Model netCDF files or Zarr store containing SSH data.
+- Model domain / mask netCDF file or Zarr store containing the longitude and latitude coordinates.
+- SWOT grid netCDF file containing the target longitude/latitude grid. It is recommended to use the "Expert" version of these files.
 - Interpolator: The script offers two interpolation methods. Scipy interpolation method and Pyinterp interpolation method. Only one method can be chosen at a time, depending on user preference.
 
-### Other Inputs:
+### Optional Inputs:
 
-- latitude_var_name: The name of the latitude variable in the model dataset (e.g., "lat" or "latitude").
-- longitude_var_name: The name of the longitude variable in the model dataset (e.g., "lon" or "longitude").
-- time_name: The name of the time variable in the model dataset (e.g., "time" or "time_counter").
-- model_ssh_var: The name of the SSH variable in the model dataset (e.g., "ssh" or "sossheig").
-- time_index: The index of the variable time, must be an integer (e.g., 0 or 2 or 3).
+- `latitude_var_name`: The name of the latitude variable in the model dataset (e.g., "lat" or "latitude").
+- `longitude_var_name`: The name of the longitude variable in the model dataset (e.g., "lon" or "longitude").
+- `time_name`: The name of the time variable in the model dataset (e.g., "time" or "time_counter").
+- `model_ssh_var`: The name of the SSH variable in the model dataset (e.g., "ssh" or "sossheig").
 
 By default, these variables are assumed to be named:
 
-- latitude for latitude_var_name
-- longitude for longitude_var_name
-- time_counter for time_name
-- ssh for model_ssh_var
-- 0 for time_index
+- latitude for `latitude_var_name`
+- longitude for `longitude_var_name`
+- time_counter for `time_name`
+- ssh for `model_ssh_var`
+
 Users should make sure to provide the correct variable names if their dataset uses different names.
 
-## 🚀 Usage:
+## 🚀 Getting Started:
 
-To use the tool, the user can clone the repository. Once the repository is cloned, the user can run the code in the `model2SWOT/model2SWOT.py` file, by executing the command line from a terminal using the following command (after navigating to the directory containing model2SWOT.py) :
+### Installation:
+
+To install the **synthocean** package, users should first clone this GitHub repository as follows:
 
 ```bash
-./model2SWOT.py -m path_to_your_model_file -k path_to_your_model_mask_file -s path_to_swot_data_file -o path_to_output_file -i interpolator --model-lat-var latitude_var_name --model-lon-var longitude_var_name --model-time-var time_name --model_ssh_var the_model_ssh_variable_name --model_timestep_index time_index
+git clone git@github.com:Amine-ouhechou/synthocean.git
 ```
-Where:
--m is the path to your model file containing the SSH data.
--k is the path to your model mask file.
--s is the path to the directory containing the SWOT data files.
--o is the path to the output directory where results will be saved.
--i specifies the interpolation method (choose between scipy_interpolation or pyinterp_interpolation).
 
+Once users have successfully cloned the repository, the `model2swot` command line interface (CLI) can be installed using pip (editable install) as follows:
+
+```bash
+cd synthocean
+pip install -e .
+```
+
+### Usage:
+
+To use the tool, users can run the `model2swot` command followed by the required arguments to run the interpolation of model outputs onto a given SWOT swath:
+
+```bash
+model2swot -m path_to_your_model_file -k path_to_your_model_mask_file -s path_to_swot_data_file -o path_to_output_file -i interpolator --model_lat_var latitude_var_name --model_lon_var longitude_var_name --model_time_var time_name --model_ssh_var the_model_ssh_variable_name
+```
+
+**Note:** When specifying a model SSH file including mutliple time-slices (e.g., daily-mean SSH fields stored in a monthly netCDF file), the nearest time-slice to the average time of the given SWOT swath will be used. The selected model time-slice is reported to users in the log.
+
+#### Required Arguments:
+
+| Flag | Name | Description |
+|---|---|---|
+| -m | Model SSH file | Path to model file containing the SSH data. |
+| -k | Model Mask file | Path to model mask / domain file containing longitude-latitude data. |
+| -s | SWOT grid file | Path to SWOT swath file containing longitude-latitude grid to interpolate onto. |
+| -o | Output file | Path to the output file where results will be saved as netCDF file. |
+| -i | Interpolation | Interpolation method (choose between "scipy_interpolation" or "pyinterp_interpolation"). |
+
+#### Optional Arguments:
+
+| Flag  | Description |
+|---|---|
+| --model_lat_var | Model latitude variable name |
+| --model_lon_var | Model longitude variable name |
+| --model_time_var | Model time variable name |
+| --model_ssh_var | Model SSH variable name |
 
 ## ⚡ Notes
-- If the model mask and data are in the same file, you need to provide the path to this file twice — once for the data and once for the mask argument.
-- Input file (model and mask) **must be either a NetCDF or zarr file** (`.nc, .zarr`).
-- The output file **must be a NetCDF file** (`.nc`).
+- If the model mask and data are in the same file, users should provide the path to this file twice — once for the data and once for the mask argument. The file will only be read once.
+- Model input files **must be either a netCDF files or Zarr stores** (`.nc` or `.zarr`).
+- Output file **must be a NetCDF file** (`.nc`).
+- SWOT gridded datasets are provided [here](https://ige-meom-opendap.univ-grenoble-alpes.fr/thredds/catalog/meomopendap/extract/MEOM/SWOT-geometry/catalog.html)
 
 The tool is currently tested with **eORCA25** and **eNATL60** data in **NetCDF** and **Zarr** format.
 
-The data needed for testing will soon be provided via **link**.
-
-The tool will soon be available for installation via pip.
-
-> [!TIP]  
-> This code requires the use of the SWOT dataset, which is provided [here](https://ige-meom-opendap.univ-grenoble-alpes.fr/thredds/catalog/meomopendap/extract/MEOM/SWOT-geometry/catalog.html)
-> 
 ## 🐛 Issues and Contributions
 
 If you encounter any issues or would like to contribute, please feel free to [open an issue here](https://github.com/Amine-ouhechou/synthocean/issues).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ To install the **synthocean** package, users should first clone this GitHub repo
 git clone git@github.com:Amine-ouhechou/synthocean.git
 ```
 
-Once users have successfully cloned the repository, the `model2swot` command line interface (CLI) can be installed using pip (editable install) as follows:
+Once users have successfully cloned the repository, users need to install the required dependencies using conda:
+
+```bash
+conda install numpy xarray netcdf4 inpoly scipy pyinterp
+```
+
+Finally, the `model2swot` command line interface (CLI) can be installed using pip (editable install) as follows:
 
 ```bash
 cd synthocean

--- a/examples/run_eorca12_era5v1_model2swot.slurm
+++ b/examples/run_eorca12_era5v1_model2swot.slurm
@@ -1,0 +1,72 @@
+#!/bin/bash
+#SBATCH --job-name=swot_eorca12_npd_
+#SBATCH --time=06:00:00
+#SBATCH --ntasks=1
+#SBATCH --mem=10GB
+
+#SBATCH --account=my_account
+#SBATCH --partition=serial
+#SBATCH --qos=serial
+
+# ==============================================================
+# run_npd_eorca12_era5v1_swot.slurm
+#
+# Description: SLURM script to perform SWOT OMIP interpolation
+# using NOC eORCA12 ERA-5v1 2024 Near-Present Day outputs.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-08-11
+#
+# ==============================================================
+# -- Input arguments to model2SWOT -- #
+# Define path to eORCA12 monthly mean output directory:
+filedir_mdl=/path/to/my/eORCA12/model/output/2024/
+# Define filepath to eORCA12 domain_cfg file:
+filepath_domain=/path/to/my/domain_cfg.nc
+
+# Define path to SWOT global grid directory:
+filedir_swot=/path/to/my/global_swot_grid_2024
+# Define output directory:
+filedir_out=/path/to/my/npd_eorca12_era5v1_global_swot_grid_2024
+
+# Define chosen interpolation method:
+interpolator="pyinterp_interpolator"
+
+# Define core variable names:
+lon_name="glamt"
+lat_name="gphit"
+time_name="time_counter"
+ssh_name="zos"
+
+# -- Python Environment -- #
+# Activate Python virtual environment:
+source /path/to/my/miniforge3/bin/activate
+conda activate env_swot
+
+# -- Interpolate eORCA12 1-day mean outputs onto SWOT grid -- #
+# Iterating over cycles:
+for cycle in {008..026}
+do
+    # Create output directory for the cycle if it doesn't exist:
+    if [ ! -d  ${filedir_out}/cycle_${cycle} ]; then
+        mkdir -p "${filedir_out}/cycle_${cycle}"
+    fi
+
+    # Define path to SWOT cycle directory:
+    filedir_swot_cycle=${filedir_swot}/cycle_${cycle}/
+    for file in $(ls ${filedir_swot_cycle})
+    do
+        echo "Interpolating eORCA12 ERA-5 v1 SSH onto SWOT grid ${file}"
+
+        # Determine YYYYMM date-string of SWOT grid input:
+        date=$(echo ${file} | grep -Eo '[[:digit:]]{4}[[:digit:]]{2}' | head -1)
+        # Define path to nearest eORCA12 T1d monthly model file:
+        fpath_mdl=$(echo ${filedir_mdl}/eORCA12_1d_grid_T_${date}-${date}.nc)
+        # Define path to interpolated output file:
+        fpath_out="${filedir_out}/cycle_${cycle}/${file/SWOT_GRID_L3_LR/eORCA12_ERA5v1_SWOT}"
+        # Run model2swot interpolator:
+        model2swot -m ${fpath_mdl} -k ${filepath_domain} -s ${filedir_swot_cycle}${file} -o ${fpath_out} -i ${interpolator} --model_lat_var ${lat_name} --model_lon_var ${lon_name} --model_time_var ${time_name} --model_ssh_var ${ssh_name}
+
+        echo "Completed: Interpolated eORCA12 ERA-5 v1 SSH onto SWOT grid."
+    done
+done

--- a/model_2SWOT/model2SWOT.py
+++ b/model_2SWOT/model2SWOT.py
@@ -1,61 +1,149 @@
-#!/usr/bin/env python3
-import argparse
-import xarray as xr
-import numpy as np
-import pyinterp
+"""
+model2SWOT.py
+
+Description:
+This module defines the CLI for the model2SWOT
+interpolation tool.
+
+"""
 import os
+import sys
+import logging
+import argparse
+import pyinterp
+import numpy as np
+import xarray as xr
 from scipy import interpolate
 from inpoly.inpoly2 import inpoly2
 
+# Define permissable interpolators:
+# TODO: xesmf inteprolator + saving weights to .nc file.
+ALLOWED_INTERPOLATORS = ['scipy_interpolator', 'pyinterp_interpolator']
+
+def initialise_logging():
+    """
+    Initialise model2SWOT logging configuration.
+    """
+    logging.basicConfig(
+        stream=sys.stdout,
+        format=">>>  Model2SWOT  <<<  | %(levelname)10s | %(asctime)s | %(message)s",
+        level=logging.INFO,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
-def read_netcdf_files(file1, file2, file3, time_name = "time_counter", time_step=0):
+def create_parser():
+    """
+    Create argument parser.
+    """
+    parser = argparse.ArgumentParser(description="A tool to process and interpolate ocean model to SWOT satellite swath",
+        formatter_class=argparse.RawTextHelpFormatter # for multiline help messages
+                                    )
+    parser.add_argument("-m", "--model_file", required=True, help="Path of the input model file (NETCDF or zarr)")
+    parser.add_argument("-k", "--mask_file", required=True, help="Path of the input mask file (NETCDF or zarr)")
+    parser.add_argument("-s", "--swot_file", required=True, help="Path of the input SWOT file (NETCDF or zarr)")
+    parser.add_argument("-o", "--output_file", required=True, help="Path of the output NETCDF file")
+
+    parser.add_argument("-i", "--interpolator", type=validate_interpolator, required=True,
+                        help=f"The interpolation method to use. "
+                             f"Supported methods are: {', '.join(ALLOWED_INTERPOLATORS)}.\n"
+                             f"Choose one from the list based on your needs.")
+    
+    # Arguments for model's (lat/lon) variable names:
+    parser.add_argument("--model_lat_var", default="latitude",
+                        help="Name of the latitude variable in the model NetCDF file (default: latitude).")
+    parser.add_argument("--model_lon_var", default="longitude",
+                        help="Name of the longitude variable in the model NetCDF file (default: longitude).")
+    parser.add_argument("--model_time_var", default="time_counter",
+                        help="Name of the time variable in the model NetCDF file (default: time_counter).")
+    parser.add_argument("--model_ssh_var", default="ssh", 
+                        help="Name of the variable in the model file to interpolate (e.g., 'ssh', 'sossheig', ...)")
+
+    return parser
+
+def read_netcdf_files(
+    file1:str,
+    file2:str,
+    file3:str,
+    time_name:str="time_counter",
+):
     """
     Reads three NetCDF files and returns the datasets.
     
-    Parameters:
-        file1 (str): Path to the first NetCDF file (Model).
-        file2 (str): Path to the second NetCDF file (Mask for model).
-        file3 (str): Path to the third NetCDF file (SWOT data).
-        
-    Returns:
-        tuple: A tuple containing three xarray datasets.
+    Parameters
+    ----------
+    file1 : str
+        Path to the first NetCDF file (Model).
+    file2 : str
+        Path to the second NetCDF file (Mask for model).
+    file3 : str
+        Path to the third NetCDF file (SWOT data).
+    time_name : str, optional
+        Name of the time dimension (default is "time_counter").
+
+    Returns
+    -------
+    tuple
+        A tuple containing three xarray datasets.
     """
     
-    # file extensions ...
+    # File extensions ...
     extension1 = os.path.splitext(file1)[1]
     extension2 = os.path.splitext(file2)[1]
-    
-    # Open datasets depending on format
+
+    # Open Datasets depending on format:
     ds1 = xr.open_dataset(file1) if extension1 == ".nc" else xr.open_zarr(file1) # model
-    
+
     if file1 == file2:
-        ds2 = ds1         # save memory if data and mask are in the same file
+        ds2 = ds1  # save memory if data and mask are in the same file
     else:
         ds2 = xr.open_dataset(file2) if extension2 == ".nc" else xr.open_zarr(file2) #mask model 
-        
+
+    # Open SWOT grid Dataset:
     ds3 = xr.open_dataset(file3)
 
-    # Select first time step if a time dimension exists (SWOT only needs 2D fields)
-    ds1 = ds1.isel({time_name: int(time_step)}) if time_name in ds1.dims else ds1  # indeed, if the dataset has time dimension. For the moment only one time step is needed
-    
+    # Select first time step if a time dimension exists (SWOT only needs 2D fields):
+    if time_name in ds1.dims:
+        if ds1[time_name].size == 1:
+            ds1 = ds1.squeeze()  # remove time dimension if it has only one value
+        elif ds1[time_name].size > 1:
+            ds1 = ds1.sel({time_name: ds3.time.mean()}, method="nearest")
+            logging.info(f"Selecting nearest time step from model dataset: {ds1[time_name].values}")
+            ds1 = ds1.squeeze()
+
     return ds1, ds2, ds3
 
 
-def select_area(lat, lon, var, latitude_array, longitude_array):
+def select_area(
+    lat:xr.DataArray,
+    lon:xr.DataArray,
+    var:xr.DataArray,
+    latitude_array:xr.DataArray,
+    longitude_array:xr.DataArray
+):
     """
     Selects the subset of model data (lon, lat, var) located within a swath defined by satellite coordinates.
     
-    Parameters:
-    - lat, lon: 2D arrays of model grid coordinates.
-    - var: 2D array of the variable to interpolate.
-    - latitude_array, longitude_array: 2D arrays of SWOT swath coordinates.
-    
-    Returns:
-    - lon_in, lat_in, var_in: 1D arrays of the filtered model data inside the swath.
+    Parameters
+    ----------
+    lat : xr.DataArray
+        Latitude coordinates of the model grid.
+    lon : xr.DataArray
+        Longitude coordinates of the model grid.
+    var : xr.DataArray
+        Variable data to be selected.
+    latitude_array : xr.DataArray
+        Latitude coordinates of the SWOT swath.
+    longitude_array : xr.DataArray
+        Longitude coordinates of the SWOT swath.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the selected longitude, latitude, and variable data.
     """
     
-    # Remove invalid points (0, 0)
+    # Remove invalid points (0, 0):
     mask_valid = ~((lon.flatten() == 0) & (lat.flatten() == 0))
     lon_clean = lon.flatten()[mask_valid]
     lat_clean = lat.flatten()[mask_valid]
@@ -63,11 +151,11 @@ def select_area(lat, lon, var, latitude_array, longitude_array):
     
     points = np.column_stack((lon_clean, lat_clean))
         
-    # Adjust longitudes to [-180, 180]
+    # Adjust longitudes to [-180, 180]:
     X = xr.where(longitude_array <= 180, longitude_array, longitude_array - 360)
     Y = latitude_array
     
-    # Polygon with margin
+    # Polygon with margin:
     dy = Y.values[-1,0] - Y.values[0,0]
     
     k = 2 if dy > 0 else -2
@@ -86,10 +174,7 @@ def select_area(lat, lon, var, latitude_array, longitude_array):
         Y.isel(num_lines=-1).values[::-1]+k,
         Y.isel(num_pixels=0).values[::-1]+k1
     ])
-    
-    
-    
-    
+
     polygon = np.column_stack((xx, yy))  
     inside, on_edge = inpoly2(points, polygon)
     mask = inside | on_edge
@@ -101,43 +186,55 @@ def select_area(lat, lon, var, latitude_array, longitude_array):
     return lon_in, lat_in, var_in
 
 
-
-def open_model_data(ds_var, ds_coords,interpolator, var, latitude_array, longitude_array, lat_name="latitude", lon_name="longitude",time_step=0):
+def open_model_data(
+    ds_var,
+    ds_coords,
+    interpolator,
+    var,
+    latitude_array,
+    longitude_array,
+    lat_name="latitude",
+    lon_name="longitude",
+):
     """
     Creates an interpolator from a model dataset containing the ssh variable.
     The spatial coordinates (latitude and longitude) are provided as 2D variables in a separate dataset.
 
-    Parameters:
-    - ds_var (xarray.Dataset): Dataset containing the model ssh to interpolate.
-    - ds_coords (xarray.Dataset): Dataset containing latitude and longitude as 2D variables.
-    - var (str): Name of the variable to interpolate.
-    - latitude_array (xarray.DataArray or np.array): Latitude of each satellite pixel (shape = [num_lines, num_pixels])
-    - longitude_array (xarray.DataArray or np.array): Longitude of each satellite pixel (shape = [num_lines, num_pixels])
-    - lat_name (str, optional): Name of the latitude variable in ds_coords (default: "latitude").
-    - lon_name (str, optional): Name of the longitude variable in ds_coords (default: "longitude").
-    
-    
-    Returns:
-    - finterp (LinearNDInterpolator): Interpolator for irregular 2D (latitude, longitude) grid.
+    Parameters
+    ----------
+    ds_var : xarray.Dataset
+        Dataset containing the model ssh to interpolate.
+    ds_coords : xarray.Dataset
+        Dataset containing latitude and longitude as 2D variables.
+    var : str
+        Name of the variable to interpolate.
+    latitude_array : xarray.DataArray or np.array
+        Latitude of each satellite pixel (shape = [num_lines, num_pixels])
+    longitude_array : xarray.DataArray or np.array
+        Longitude of each satellite pixel (shape = [num_lines, num_pixels])
+    lat_name : str, optional
+        Name of the latitude variable in ds_coords (default: "latitude").
+    lon_name : str, optional
+        Name of the longitude variable in ds_coords (default: "longitude").
+
+    Returns
+    -------
+    finterp : LinearNDInterpolator
+        Interpolator for irregular 2D (latitude, longitude) grid.
     """
-    
-    # Check if the variable exists in ds_var
+    # Check if the variable exists in ds_var:
     if var not in ds_var:
         raise ValueError(f"Variable '{var}' is not present in the provided dataset.")
 
-    # Extract latitude and longitude from ds_coords (as 2D arrays)
+    # Extract latitude and longitude from ds_coords (as 2D arrays):
     try:
         lat_values = ds_coords[lat_name].values  # Shape (x, y)
         lon_values = ds_coords[lon_name].values  # Shape: x, y)
     except KeyError:
         raise ValueError(f"Could not find '{lat_name}' or '{lon_name}' in the coordinates dataset.")
 
-    # Extract variable values
-    var_values = ds_var[var].values  
-    
-    # Ensure the variable has the correct dimensions (latitude, longitude)
-    if var_values.ndim == 3:  # If an extra time dimension exists
-        var_values = var_values[time_step]  # Take only the first time step
+    # Extract variable values:
+    var_values = ds_var[var].values
 
     lon_in, lat_in, var_in = select_area(lon=lon_values,
                                          lat=lat_values,
@@ -145,58 +242,71 @@ def open_model_data(ds_var, ds_coords,interpolator, var, latitude_array, longitu
                                          latitude_array=latitude_array,
                                          longitude_array=longitude_array
                                         )
-    
-    
-    
-    # Flatten the 2D grid into 1D arrays
+
+    # Flatten the 2D grid into 1D arrays:
     lat_flat = lat_in # lat_values.flatten()
     lon_flat = lon_in # lon_values.flatten()
     var_flat = var_in # var_values.flatten()
-    
+
     if np.size(var_flat)!=0: #Checking is not empty
-        
-        # Create a scattered data interpolator  !!!!!!! car c'est irregular 2D grids)
+        # Create a scattered data interpolator (car c'est irregular 2D grids):
         if interpolator == "scipy_interpolator":
-            
             finterp = interpolate.LinearNDInterpolator(
                list(zip(lat_flat, lon_flat)),
                 var_flat,
                 fill_value=np.nan
             )
-        
-        elif interpolator == "pyinterp_interpolator":
 
+        elif interpolator == "pyinterp_interpolator":
             points = np.column_stack((lon_flat, lat_flat))
             finterp = pyinterp.RTree()
             finterp.packing(points, var_flat)
         else:
             raise ValueError(f"Unknown interpolator: {interpolator}")
-    
 
         return finterp
     else:
         return 0
 
 
-
-def interp_satellite(latitude_array, longitude_array,cross_dist,quality_flag, interpolator, interp, var):
+def interp_satellite(
+    latitude_array:xr.DataArray | np.ndarray,
+    longitude_array:xr.DataArray | np.ndarray,
+    cross_dist:xr.DataArray | np.ndarray,
+    quality_flag:xr.DataArray | np.ndarray,
+    interpolator:str,
+    interp:interpolate.LinearNDInterpolator | pyinterp.RTree,
+    var:str,
+):
     """
     Interpolates the modeled SSH at satellite observation points (wide swath only).
 
-    Parameters:
-    - latitude_array (xarray.DataArray or np.array): Latitude of each satellite pixel (shape = [num_lines, num_pixels])
-    - longitude_array (xarray.DataArray or np.array): Longitude of each satellite pixel (shape = [num_lines, num_pixels])
-    - interp (scipy.interpolate.LinearNDInterpolator): Interpolator from `open_model_data`
-    - var (str): Name of the ssh variable (e.g., "ssh_debug")
-    - cross_dist and quality_flag are used to build the mask
+    Parameters
+    ----------
+    latitude_array : xarray.DataArray | np.ndarray
+        Latitude of each satellite pixel (shape = [num_lines, num_pixels])
+    longitude_array : xarray.DataArray | np.ndarray
+        Longitude of each satellite pixel (shape = [num_lines, num_pixels])
+    cross_dist : xarray.DataArray | np.ndarray
+        Cross-track distance of each satellite pixel (shape = [num_lines, num_pixels])
+    quality_flag : xarray.DataArray | np.ndarray
+        Quality flag for each satellite pixel (shape = [num_lines, num_pixels])
+    interpolator : str
+        Interpolator type to use (e.g., "scipy_interpolator" or "pyinterp_interpolator")
+    interp : interpolate.LinearNDInterpolator | pyinterp.RTree
+        Interpolator object created from the model data
+    var : str
+        Name of the ssh variable (e.g., "ssh_debug")
 
-    Returns:
-    - ds (xarray.Dataset): Dataset of interpolated SSH values, structured for wide swath data.
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset of interpolated SSH values, structured for wide swath data.
     """
-    
+
     # Ensure latitude and longitude are NumPy arrays before flattening
     longitude_array = xr.where(longitude_array>180 , longitude_array-360, longitude_array)  # swot longitude conversion from 0/360 to 180/-180
-    
+
     latitude_array = np.asarray(latitude_array)
     longitude_array = np.asarray(longitude_array)
 
@@ -204,14 +314,14 @@ def interp_satellite(latitude_array, longitude_array,cross_dist,quality_flag, in
     points = np.column_stack((latitude_array.flatten(), longitude_array.flatten()))
 
     # Apply the interpolator to get SSH values at satellite positions
-    
-    print("Interpolation in progress ...")
-    
+
+    logging.info("In Progress: Interpolating model SSH onto SWOT grid...")
+
     if interpolator == "scipy_interpolator":
         # Flatten the satellite lat/lon arrays to feed into the interpolator
         points = np.column_stack((latitude_array.flatten(), longitude_array.flatten()))       
         ssh_interp = interp(points).reshape(latitude_array.shape)
-         
+
     elif interpolator == "pyinterp_interpolator":
         points = np.column_stack((longitude_array.flatten(), latitude_array.flatten()))
         ssh_interp = interp.inverse_distance_weighting(
@@ -221,7 +331,7 @@ def interp_satellite(latitude_array, longitude_array,cross_dist,quality_flag, in
             p=2,  #The power to be used by the interpolator inverse_distance_weighting.
             within=True
             )[0].reshape(latitude_array.shape) 
-               
+
     # Rename variable if needed
     if var != "ssh":
         var = "ssh"
@@ -234,8 +344,7 @@ def interp_satellite(latitude_array, longitude_array,cross_dist,quality_flag, in
         "longitude": (["num_lines", "num_pixels"], longitude_array)
     })
     
-    
-    # removing data from where swot does not have any (inter-swath and periphery areas) and from the continent (eventually) [see quality flag in the documentation]
+    # Removing data from where swot does not have any (inter-swath and periphery areas) and from the continent (eventually) [see quality flag in the documentation]
     # Only values between 10 and 60 km to the nadir are considered as valid data. https://www.aviso.altimetry.fr/fileadmin/documents/data/tools/hdbk_duacs_SWOT_L3.pdf                                                                                               
     mask = xr.where((abs(cross_dist)<=60.0) & (abs(cross_dist)>=10.0) & (quality_flag<101) ,cross_dist,np.nan)                                                                             
     ds["ssh"] = ds["ssh"].where(~np.isnan(mask))
@@ -245,17 +354,10 @@ def interp_satellite(latitude_array, longitude_array,cross_dist,quality_flag, in
     return ds
 
 
-def save_netcdf(result, output_file):
-    """
-    Save the resulting dataset to a NetCDF file.
-    """
-    result.to_netcdf(output_file)
-
-
-ALLOWED_INTERPOLATORS = ['scipy_interpolator', 'pyinterp_interpolator']
-
 def validate_interpolator(value):
-    """function to validate the interpolator argument."""
+    """
+    Validate the interpolator argument.
+    """
     if value.lower() not in ALLOWED_INTERPOLATORS:
         raise argparse.ArgumentTypeError(
             f"Invalid interpolator method: '{value}'. "
@@ -264,55 +366,55 @@ def validate_interpolator(value):
     return value.lower() 
 
 
-def main():
-    parser = argparse.ArgumentParser(description="A tool to process and interpolate ocean model to SWOT satellite swath",
-        formatter_class=argparse.RawTextHelpFormatter # for multiline help messages
-                                    )
-    parser.add_argument("-m", "--model_file", required=True, help="Path of the input model file (NETCDF or zarr)")
-    parser.add_argument("-k", "--mask_file", required=True, help="Path of the input mask file (NETCDF or zarr)")
-    parser.add_argument("-s", "--swot_file", required=True, help="Path of the input SWOT file (NETCDF or zarr)")
-    parser.add_argument("-o", "--output_file", required=True, help="Path of the output NETCDF file")
-
-    parser.add_argument("-i", "--interpolator", type=validate_interpolator, required=True,
-                        help=f"The interpolation method to use. "
-                             f"Supported methods are: {', '.join(ALLOWED_INTERPOLATORS)}.\n"
-                             f"Choose one from the list based on your needs.")
-    
-    # Arguments for model's (lat/lon) variable names
-    parser.add_argument("--model_lat_var", default="latitude",
-                        help="Name of the latitude variable in the model NetCDF file (default: latitude).")
-    parser.add_argument("--model_lon_var", default="longitude",
-                        help="Name of the longitude variable in the model NetCDF file (default: longitude).")
-    parser.add_argument("--model_time_var", default="time_counter",
-                        help="Name of the time variable in the model NetCDF file (default: time_counter).")
-    parser.add_argument("--model_ssh_var", default="ssh", 
-                        help="Name of the variable in the model file to interpolate (e.g., 'ssh', 'sossheig', ...)")
-    parser.add_argument("--model_timestep_index", default=0, 
-                        help="Time step index in the model file to interpolate (by default is the first time-step)")
+def model2swot():
+    """
+    Main function to perform ocean model to SWOT interpolation.
+    """
+    # Logging to stdout:
+    initialise_logging()
+    # Parse CL args:
+    parser = create_parser()
     args = parser.parse_args()
 
-    # Pre-check existence of input files
+    # Pre-check existence of input files:
     for f in [args.model_file, args.mask_file, args.swot_file]:
         if not os.path.exists(f):
             parser.error(f"Error: Input file not found: {f}")
         if not os.path.isfile(f):
             parser.error(f"Error: Path is not a file: {f}")
 
-    # read files
+    # Set interpolator:
     interpolator = args.interpolator
-    print(f"Processing with interpolator: {interpolator}")
-    ds_model, ds_mask, ds_swot = read_netcdf_files(args.model_file, args.mask_file, args.swot_file, args.model_time_var,args.model_timestep_index)
-    # Analyse
-    finterp = open_model_data(ds_model, ds_mask,interpolator, args.model_ssh_var, ds_swot.latitude, ds_swot.longitude, args.model_lat_var, args.model_lon_var,args.model_timestep_index)
+    logging.info(f"In Progress: Processing with {interpolator.split('_')[0]} interpolator...")
+    # Read input netCDF files:
+    ds_model, ds_mask, ds_swot = read_netcdf_files(args.model_file,
+                                                   args.mask_file,
+                                                   args.swot_file,
+                                                   args.model_time_var,
+                                                   )
+    # Subset model data using SWOT swath:
+    finterp = open_model_data(ds_model,
+                              ds_mask,
+                              interpolator,
+                              args.model_ssh_var,
+                              ds_swot.latitude,
+                              ds_swot.longitude,
+                              args.model_lat_var,
+                              args.model_lon_var
+                              )
+
+    # Writing outputs to netCDF:
     if finterp !=0: # Checking finterp is not empty
-        output_ds = interp_satellite(ds_swot.latitude, ds_swot.longitude, ds_swot.cross_track_distance, ds_swot.quality_flag, interpolator, finterp, var="ssh")
-        # Sauvegarder le fichier
-        save_netcdf(output_ds, args.output_file)
-        print("Script finished successfully")
+        output_ds = interp_satellite(ds_swot.latitude,
+                                     ds_swot.longitude,
+                                     ds_swot.cross_track_distance,
+                                     ds_swot.quality_flag,
+                                     interpolator,
+                                     finterp,
+                                     var="ssh"
+                                     )
+        output_ds.to_netcdf(args.output_file)
+        logging.info("Completed: Interpolation finished successfully.")
     else:
-        print("The model has no information for the SWOT path")
-
-if __name__ == "__main__":
-    main()
-
- 
+        logging.info("Error: Model input has no information for the SWOT path.")
+    sys.exit(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Package to interpolate ocean model data to SWOT swath"
 readme = "README.md"
 requires-python = ">=3.7"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 keywords = ["ocean models", "Swot swath", "Interpolation"]
 authors = [
   { name = "Amine Ouhechou", email = "amine.ouhechou@univ-grenoble-alpes.fr" },
@@ -13,15 +13,26 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache-2.0",
     "Operating System :: OS Independent"
 ]
+
+dependencies = [
+"xarray",
+"numpy",
+"pyinterp",
+"scipy",
+"inpoly",
+  ]
 
 [project.urls]
 Repository = "https://github.com/Amine-ouhechou/synthocean"
 
-
-
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["model_2SWOT"]
+
+[project.scripts]
+model2swot = "model_2SWOT.model2SWOT:model2swot"


### PR DESCRIPTION
Hi Amine, 

My name is Ollie Tooth, I'm an ocean modeller at the National Oceanography Centre in the UK. 
I've recently been working with the synthocean package for the SWOT MIP project and noticed a few bug fixes / improvements that could be made to make life easier for users. I have implemented them in this PR and included the details below:

- Added logging to replace print statements to update users on script progress.
- Added type hinting and numpy docstrings.
- Replaced selection of first time-step from model SSH input dataset with selection of the nearest time-step to the average time of the provided SWOT swath.
- Refactored the argument parsing into separate function to be called from main() -> renamed model2swot().
- Defined model2swot() as a [project.script] in the pyproject.toml file, so that once users have locally installed via pip (pip install -e .) the script can be called from the command line using model2swot -m .... -k ... etc.
- Added details on installation and table of updated arguments to README.md
- Added an example bash script on how to use the model2swot tool at scale: performing interpolation onto all available 2024 SWOT grids dataset linked in the **Tips** section using a 1/12 eORCA12 NEMO model. (No output files have been included, just a template of the procedure to select the appropriate files and perform the interpolation etc.)

Feel free to include / reject any of the above - creating this fork helped me learn how the tool was working behind the scenes and speed up my workflow for the SWOT MIP. This was done quite hastily, so I'm sure you can make lots of further improvements to my suggestions!

Thanks,

Ollie